### PR TITLE
perf(macos): use gethostuuid(3) instead of shelling out to ioreg

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,3 +20,6 @@ windows-registry = "0.6.1"
 
 [target.'cfg(target_os = "illumos")'.dependencies]
 libc = "0.2.177"
+
+[target.'cfg(target_os = "macos")'.dependencies]
+libc = "0.2.177"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,8 +40,8 @@
 //!
 //! OSX:
 //!
-//! ```Bash
-//! ioreg -rd1 -c IOPlatformExpertDevice | grep IOPlatformUUID
+//! ```C
+//! gethostuuid(3) // same value as `ioreg -rd1 -c IOPlatformExpertDevice`
 //! ```
 //!
 //! Windows:
@@ -131,30 +131,49 @@ pub mod machine_id {
 
 #[cfg(target_os = "macos")]
 mod machine_id {
-    // machineID returns the uuid returned by `ioreg -rd1 -c IOPlatformExpertDevice`.
+    // Returns the same UUID exposed by `ioreg -rd1 -c IOPlatformExpertDevice`
+    // (i.e. `IOPlatformUUID`), but via the BSD `gethostuuid(3)` syscall.
+    //
+    // Both surfaces are fronted by the same kernel data, so the value is
+    // bit-for-bit identical (same hyphenation, same uppercase hex). Going
+    // through libc avoids a fork+exec of `ioreg` per call, which on macOS
+    // costs ~90ms (subprocess + dyld + IOKit init) versus ~10µs for the
+    // syscall.
     use std::error::Error;
-    use std::process::Command;
+    use std::io;
 
     /// Return machine id
     pub fn get_machine_id() -> Result<String, Box<dyn Error>> {
-        let output = Command::new("ioreg")
-            .args(&["-rd1", "-c", "IOPlatformExpertDevice"])
-            .output()?;
-        let content = String::from_utf8_lossy(&output.stdout);
-        extract_id(&content)
-    }
-
-    fn extract_id(content: &str) -> Result<String, Box<dyn Error>> {
-        let lines = content.split('\n');
-        for line in lines {
-            if line.contains("IOPlatformUUID") {
-                let k: Vec<&str> = line.rsplitn(2, '=').collect();
-                let id = k[0].trim_matches(|c: char| c == '"' || c.is_whitespace());
-                return Ok(id.to_string());
-            }
+        let mut uuid: [u8; 16] = [0; 16];
+        // A zero `timespec` requests an indefinite wait. In practice the
+        // call returns immediately; the timeout only matters when the
+        // hostuuid has not yet been initialized very early in boot.
+        let wait = libc::timespec {
+            tv_sec: 0,
+            tv_nsec: 0,
+        };
+        let rc = unsafe { libc::gethostuuid(uuid.as_mut_ptr(), &wait) };
+        if rc != 0 {
+            return Err(Box::new(io::Error::last_os_error()));
         }
-        Err(From::from(
-            "No matching IOPlatformUUID in `ioreg -rd1 -c IOPlatformExpertDevice` command.",
+        Ok(format!(
+            "{:02X}{:02X}{:02X}{:02X}-{:02X}{:02X}-{:02X}{:02X}-{:02X}{:02X}-{:02X}{:02X}{:02X}{:02X}{:02X}{:02X}",
+            uuid[0],
+            uuid[1],
+            uuid[2],
+            uuid[3],
+            uuid[4],
+            uuid[5],
+            uuid[6],
+            uuid[7],
+            uuid[8],
+            uuid[9],
+            uuid[10],
+            uuid[11],
+            uuid[12],
+            uuid[13],
+            uuid[14],
+            uuid[15],
         ))
     }
 }


### PR DESCRIPTION
## Summary

`get_machine_id()` on macOS shells out to `ioreg -rd1 -c IOPlatformExpertDevice` and string-parses the `IOPlatformUUID` line. Per call this costs roughly 10–90ms depending on hardware, dominated by fork+exec, dyld, code-signature verification, and IOKit framework init. For tools that read the machine id on every invocation, this adds up.

The same UUID is fronted by the BSD [`gethostuuid(3)`](https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man3/gethostuuid.3.html) syscall — bit-for-bit identical output (same hyphenation, same uppercase hex), available since macOS 10.5, no entitlements required, no sandbox restriction by default. Going through `libc` removes the subprocess entirely.

## Benchmark (Apple Silicon)

|                       | per call         |
| --------------------- | ---------------- |
| `ioreg` shell-out     | ~14 ms           |
| `gethostuuid(3)`      | ~920 ns          |

About **~15,000× faster** in-process. On older Intel hardware the gap is closer to ~9,000× (90ms → 10µs), as measured in [nrwl/nx#35599](https://github.com/nrwl/nx/pull/35599) where this approach was first applied locally.

## Output equivalence

Verified on the same machine:

```
ioreg:        E910C87E-2AB7-5A8D-8E7A-4047C0B994ED
gethostuuid:  E910C87E-2AB7-5A8D-8E7A-4047C0B994ED
```

The format string preserves the existing crate output exactly: uppercase hex, 8-4-4-4-12 hyphenation. Existing consumers that may have cached the previous return value (e.g. as a key) see no change.

## Implementation notes

- `libc` dependency is gated on `cfg(target_os = "macos")`, mirroring the existing illumos branch which already uses `libc::gethostid()` directly.
- The Rust `libc` binding for `gethostuuid` landed in [rust-lang/libc#2216](https://github.com/rust-lang/libc/pull/2216) (Apr 2021), which is why the original macOS path predates this option.
- A zero `timespec` requests an indefinite wait. In practice the call returns immediately; the timeout only matters when the hostuuid has not yet been initialized very early in boot.
- On non-zero return, the OS error is surfaced via `io::Error::last_os_error()` rather than swallowed.

## Test plan

- [x] `cargo build` — clean
- [x] `cargo test` — `test_get` and `test_not_empty` pass
- [x] Output compared byte-for-byte against `ioreg -rd1 -c IOPlatformExpertDevice | grep IOPlatformUUID` on macOS — identical
- [x] In-process micro-benchmark (1000 iters) shows ~920ns/call vs ~14ms/call previously
